### PR TITLE
Delete processed keys to avoid double stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(req, res, next) {
 			for(var key in req.files) {
 				if (req.files.hasOwnProperty(key)) {
 					file = req.files[key];
+					delete req.files[key]; // avoids double stats
 					fs.stat(file.path, function(err, stats) {
 						if (!err && stats.isFile()) {
 							fs.unlink(file.path);


### PR DESCRIPTION
This assumes nobody is going to access req.files after multer-autoreap.
