### PR TITLE
Adding error callback to fs unlink

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ module.exports = function(req, res, next) {
 					delete req.files[key]; // avoids stating previously reaped files
 					fs.stat(file.path, function(err, stats) {
 						if (!err && stats.isFile()) {
-							fs.unlink(file.path);
+							fs.unlink(file.path, function(err) {
+								if (err) throw err;
+							});
 							debug('removed %s', file.path);
 							res.emit('autoreap', file);
 						}


### PR DESCRIPTION

unlink requires an error callback: http://nodejs.org/api/fs.html#fs_fs_unlink_path_callback